### PR TITLE
[Refactor] 플레이어 전적 갱신 리팩토링

### DIFF
--- a/src/main/java/com/menu/pubganalyzer/domain/model/Match.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/model/Match.java
@@ -9,6 +9,7 @@ import com.menu.pubganalyzer.util.pubgAPI.response.MatchResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.Hibernate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -159,5 +160,18 @@ public class Match {
                 ", matchType=" + matchType +
                 ", createdAt=" + createdAt +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Match match = (Match) o;
+        return getId() != null && Objects.equals(getId(), match.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
     }
 }

--- a/src/main/java/com/menu/pubganalyzer/event/listener/MatchEventListener.java
+++ b/src/main/java/com/menu/pubganalyzer/event/listener/MatchEventListener.java
@@ -9,7 +9,9 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -20,7 +22,11 @@ public class MatchEventListener {
     @Async("sqlExecutor")
     @EventListener
     public void saveMatches(SaveMatchesEvent event) {
-        Collection<Match> matches = event.getMatches();
+        Set<Match> matches = new HashSet<>(event.getMatches());
+
+        List<Match> exists = matchRepository.findAllById(Match.extractIds(matches));
+        exists.forEach(matches::remove);
+
         log.info("매치 DB insert 시작 matches size:{}", matches.size());
         long start = System.currentTimeMillis();
         matchRepository.saveAll(matches);

--- a/src/main/java/com/menu/pubganalyzer/facade/PlayerFacadeImpl.java
+++ b/src/main/java/com/menu/pubganalyzer/facade/PlayerFacadeImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -86,7 +87,10 @@ public class PlayerFacadeImpl implements PlayerFacade {
 
         Set<String> matchIds = player.getMatchIds();
 
-        Set<Match> matches = matchFacade.findById(matchIds);
+        Set<Match> matches = matchIds.stream()
+                .parallel()
+                .map(matchFacade::findById)
+                .collect(Collectors.toSet());
 
         matchInsertStrategy.insert(matches);
 
@@ -96,8 +100,8 @@ public class PlayerFacadeImpl implements PlayerFacade {
         }
 
         participants.sort((p1, p2) -> {
-            Match m1 = p1.getRoster().getMatch();
-            Match m2 = p2.getRoster().getMatch();
+            Match m1 = p1.getMatch();
+            Match m2 = p2.getMatch();
             int order = m1.getCreatedAt().compareTo(m2.getCreatedAt());
             return order * -1;
         });

--- a/src/main/java/com/menu/pubganalyzer/service/SearchPlayerService.java
+++ b/src/main/java/com/menu/pubganalyzer/service/SearchPlayerService.java
@@ -27,7 +27,7 @@ public class SearchPlayerService {
 
     @Cacheable(value = "renew_players", key = "#nickname")
     public boolean renew(Shard shard, String nickname) {
-        playerFacade.renewSync(shard, nickname);
+        playerFacade.renewAsync(shard, nickname);
         return true;
     }
 }


### PR DESCRIPTION
- 모든 매치가 이미 db에 저장되어있는 상태에서도 약 65개의 매치 처리 시 10초 이상의 느린 성능을 보임.
- 플레이어 전적 갱신 시 기존에 존재하는 매치는 제외하고 db에 insert하도록 수정.
- db insert 비동기적으로 처리