### PR TITLE
[Hotfix] 전적 갱신시 전적이 중복으로 저장되는 문제 수정

### DIFF
--- a/src/main/java/com/menu/pubganalyzer/domain/model/PlayerMatch.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/model/PlayerMatch.java
@@ -9,7 +9,8 @@ import java.util.Objects;
 
 @Entity(name = "player_match")
 @Table(indexes = {
-        @Index(name = "created_date_time_index", columnList = "createdDateTime")
+        @Index(name = "created_date_time_index", columnList = "createdDateTime"),
+        @Index(name = "player_match_index", columnList = "player_id,matchId", unique = true)
 })
 public class PlayerMatch {
     @Id

--- a/src/main/java/com/menu/pubganalyzer/domain/repository/PlayerMatchRepository.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/repository/PlayerMatchRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Set;
+
 public interface PlayerMatchRepository extends JpaRepository<PlayerMatch, Long> {
     Page<PlayerMatch> findByPlayer(Player player, Pageable pageable);
+    Set<PlayerMatch> findByPlayer(Player player);
 }

--- a/src/main/java/com/menu/pubganalyzer/event/UpdateMatchHistoryEvent.java
+++ b/src/main/java/com/menu/pubganalyzer/event/UpdateMatchHistoryEvent.java
@@ -16,6 +16,10 @@ public class UpdateMatchHistoryEvent {
         return new UpdateMatchHistoryEvent(player);
     }
 
+    public Player getPlayer() {
+        return player;
+    }
+
     public Set<PlayerMatch> getPlayerMatches() {
         return player.getPlayerMatches();
     }

--- a/src/main/java/com/menu/pubganalyzer/event/listener/PlayerEventListener.java
+++ b/src/main/java/com/menu/pubganalyzer/event/listener/PlayerEventListener.java
@@ -1,10 +1,14 @@
 package com.menu.pubganalyzer.event.listener;
 
+import com.menu.pubganalyzer.domain.model.PlayerMatch;
 import com.menu.pubganalyzer.domain.repository.PlayerMatchRepository;
 import com.menu.pubganalyzer.event.UpdateMatchHistoryEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +17,9 @@ public class PlayerEventListener {
 
     @EventListener
     public void updateMatchHistory(UpdateMatchHistoryEvent event) {
-        playerMatchRepository.saveAll(event.getPlayerMatches());
+        Set<PlayerMatch> exists = playerMatchRepository.findByPlayer(event.getPlayer());
+        Set<PlayerMatch> playerMatches = new HashSet<>(event.getPlayerMatches());
+        playerMatches.removeAll(exists);
+        playerMatchRepository.saveAll(playerMatches);
     }
 }


### PR DESCRIPTION
## Merge 전 체크리스트
- [x] PlayerMatch 유니크 컬럼 설정
- [x] 중복된 row 삭제