### PR TITLE
[Hotfix] 리포트 페이지 오류 수정

### DIFF
--- a/src/main/resources/templates/analyzer.html
+++ b/src/main/resources/templates/analyzer.html
@@ -228,12 +228,12 @@
                             <div class="col">
                                 <div class="accordion" id="kills-accordion">
                                     <div th:each="kill : ${analyze.killLog}" class="accordion-item">
-                                        <h2 class="accordion-header" th:id="${kill.victim.name + '-heading'}">
-                                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" th:data-bs-target="${'#' + kill.victim.name + '-collapse'}" aria-expanded="false" th:aria-controls="${kill.victim.name + '-collapse'}">
+                                        <h2 class="accordion-header" th:id="${'player-' + kill.victim.name + '-heading'}">
+                                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" th:data-bs-target="${'#player-' + kill.victim.name + '-collapse'}" aria-expanded="false" th:aria-controls="${'player-' + kill.victim.name + '-collapse'}">
                                                 [[${kill.victim.name}]]
                                             </button>
                                         </h2>
-                                        <div th:id="${kill.victim.name + '-collapse'}" class="accordion-collapse collapse" th:aria-labelledby="${kill.victim.name + '-heading'}" data-bs-parent="#kills-accordion">
+                                        <div th:id="${'player-' + kill.victim.name + '-collapse'}" class="accordion-collapse collapse" th:aria-labelledby="${'player-' + kill.victim.name + '-heading'}" data-bs-parent="#kills-accordion">
                                             <div class="accordion-body">
                                                 <div class="table-responsive">
                                                     <table class="table align-middle">

--- a/src/main/resources/templates/analyzer.html
+++ b/src/main/resources/templates/analyzer.html
@@ -256,7 +256,7 @@
                                                         <thead class="align-middle">
                                                         <tr>
                                                             <th rowspan="2" scope="col">Time</th>
-                                                            <th rowspan="2" scope="col">Victim</th>
+                                                            <th rowspan="2" scope="col">Attacker</th>
                                                             <th rowspan="2" scope="col">Reason</th>
                                                             <th rowspan="2" scope="col">Weapon</th>
                                                             <th rowspan="2" scope="col">Damage</th>

--- a/src/main/resources/templates/analyzer.html
+++ b/src/main/resources/templates/analyzer.html
@@ -197,7 +197,7 @@
                         </div>
                     </div>
                     <!-- 분석 -->
-                    <div class="vstack gap-4">
+                    <div th:if="${!analyze.damageLog.isEmpty()}" class="vstack gap-4">
                         <!-- 분석 그래프 -->
                         <div class="row g-4">
                             <!-- 페이즈 데미지 차트:원형 차트 -->

--- a/src/main/resources/templates/analyzer.html
+++ b/src/main/resources/templates/analyzer.html
@@ -56,9 +56,11 @@
             <!--sidebar:left-->
             <aside class="col-lg-2"></aside>
             <div class="col-lg-8">
-                <div class="d-flex mb-4">
-                    <a class="h3 m-0 text-decoration-none text-dark fw-bold" role="button" th:href="${'/players?shard=' + shard + '&nickname=' + player}">[[${player}]]</a>
-                    <div  th:if="${!member.isEmpty()}" class="ms-auto">
+                <div class="row mb-4 g-4">
+                    <div class="col">
+                        <a class="h3 m-0 text-decoration-none text-dark fw-bold" role="button" th:href="${'/players?shard=' + shard + '&nickname=' + player}">[[${player}]]</a>
+                    </div>
+                    <div th:if="${!member.isEmpty()}" class="col-md-4">
                         <div class="input-group">
                             <label class="input-group-text" for="other-player">Member</label>
                             <select class="form-select" id="other-player" onchange="if(this.value) location.href=this.value;">


### PR DESCRIPTION
- 리포트 페이지 데미지 내역이 없는 경우 분석 컴포넌트를 출력하지 않도록 수정했습니다.
- 리포트 페이지 멤버 선택 버튼을 모바일에 맞게 반응형 디자인으로 수정하였습니다.
- 킬 별 데미지 로그 테이블의 컬럼 이름을 수정했습니다. (Victim -> Attacker)
- 킬 별 데미지 아코디언이 펼쳐지지 않는 문제를 해결했습니다.