### PR TITLE
[Feat] Match RESTful API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,10 @@ jacocoTestReport {
 					dir: it,
 					includes: [
 							'com/menu/pubganalyzer/domain/dao/impl/*',
-							'com/menu/pubganalyzer/event/*/*',
 							'com/menu/pubganalyzer/util/*',
-							'com/menu/pubganalyzer/service/*',
-							'com/menu/pubganalyzer/controller/*',
+							'com/menu/pubganalyzer/util/pubgAPI/DefaultPubgAPI.class',
+							'com/menu/pubganalyzer/service/**',
+							'com/menu/pubganalyzer/controller/**',
 					],
 					excludes: [
 					])

--- a/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
+++ b/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
@@ -8,6 +8,8 @@ import com.menu.pubganalyzer.support.apiResult.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,7 +24,7 @@ public class MatchApiController {
     private final MatchService matchService;
 
     @GetMapping
-    public ApiResult<PageDTO<MatchRes>> findAll(Pageable pageable) {
+    public ApiResult<PageDTO<MatchRes>> findAll(@PageableDefault(size = 20, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<Match> matchPage = matchService.findAll(pageable);
         Page<MatchRes> matchResPage = matchPage.map(MatchRes::of);
 

--- a/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
+++ b/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
@@ -1,0 +1,30 @@
+package com.menu.pubganalyzer.controller.api;
+
+import com.menu.pubganalyzer.domain.dto.MatchRes;
+import com.menu.pubganalyzer.domain.dto.PageDTO;
+import com.menu.pubganalyzer.domain.model.Match;
+import com.menu.pubganalyzer.service.MatchService;
+import com.menu.pubganalyzer.support.apiResult.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.menu.pubganalyzer.support.apiResult.ApiResultUtil.success;
+
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+public class MatchApiController {
+    private final MatchService matchService;
+
+    @GetMapping
+    public ApiResult<PageDTO<MatchRes>> findAll(Pageable pageable) {
+        Page<Match> matchPage = matchService.findAll(pageable);
+        Page<MatchRes> matchResPage = matchPage.map(MatchRes::of);
+
+        return success(PageDTO.of(matchResPage));
+    }
+}

--- a/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
+++ b/src/main/java/com/menu/pubganalyzer/controller/api/MatchApiController.java
@@ -8,9 +8,10 @@ import com.menu.pubganalyzer.support.apiResult.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
 
 import static com.menu.pubganalyzer.support.apiResult.ApiResultUtil.success;
 
@@ -26,5 +27,12 @@ public class MatchApiController {
         Page<MatchRes> matchResPage = matchPage.map(MatchRes::of);
 
         return success(PageDTO.of(matchResPage));
+    }
+
+    @DeleteMapping("{id}")
+    public ApiResult<Map<String, String>> deleteById(@PathVariable final String id) {
+        matchService.deleteById(List.of(id));
+
+        return success(Map.of("id", id));
     }
 }

--- a/src/main/java/com/menu/pubganalyzer/domain/dao/MatchDAO.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/dao/MatchDAO.java
@@ -7,5 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface MatchDAO {
     Match findById(String id);
     Page<Match> findById(String id, Pageable pageable);
+    Page<Match> findAll(Pageable pageable);
     void deleteById(String id);
 }

--- a/src/main/java/com/menu/pubganalyzer/domain/dao/impl/MatchDAOImpl.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/dao/impl/MatchDAOImpl.java
@@ -49,6 +49,11 @@ public class MatchDAOImpl implements MatchDAO {
     }
 
     @Override
+    public Page<Match> findAll(Pageable pageable) {
+        return matchRepository.findAll(pageable);
+    }
+
+    @Override
     public void deleteById(String id) {
         Match match = matchCache.get(id, Match.class);
         if (match == null) {

--- a/src/main/java/com/menu/pubganalyzer/domain/dto/MatchRes.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/dto/MatchRes.java
@@ -1,8 +1,6 @@
 package com.menu.pubganalyzer.domain.dto;
 
 import com.menu.pubganalyzer.domain.model.Match;
-import com.menu.pubganalyzer.domain.model.Participant;
-import com.menu.pubganalyzer.domain.model.Roster;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +9,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
 
 @Getter
 @Builder
@@ -24,8 +21,6 @@ public class MatchRes {
     private boolean isCustomMatch;
     private String matchType;
     private LocalDateTime createdAt;
-    private Set<Participant> participants;
-    private Set<Roster> rosters;
 
     private MatchRes() {
     }
@@ -39,7 +34,6 @@ public class MatchRes {
                 .isCustomMatch(match.isCustomMatch())
                 .matchType(match.getMatchType().getTitle())
                 .createdAt(match.getCreatedAt())
-                .rosters(match.getRosters())
                 .build();
     }
 

--- a/src/main/java/com/menu/pubganalyzer/service/MatchService.java
+++ b/src/main/java/com/menu/pubganalyzer/service/MatchService.java
@@ -21,6 +21,10 @@ public class MatchService {
         return matchDAO.findById(id, pageable);
     }
 
+    public Page<Match> findAll(Pageable pageable) {
+        return matchDAO.findAll(pageable);
+    }
+
     @Transactional
     public void deleteById(Collection<String> ids) {
         for (String id : ids) {

--- a/src/main/java/com/menu/pubganalyzer/support/admin/AdminConfig.java
+++ b/src/main/java/com/menu/pubganalyzer/support/admin/AdminConfig.java
@@ -1,13 +1,11 @@
 package com.menu.pubganalyzer.support.admin;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RequiredArgsConstructor
 public class AdminConfig {
-    private final AdminProperties adminProperties;
+    private final AdminProperties adminProperties = new AdminProperties();
 
     @Bean
     public AdminInterceptor adminInterceptor() {

--- a/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
+++ b/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
@@ -1,0 +1,44 @@
+package com.menu.pubganalyzer.controller.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class MatchApiControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void findAll() throws Exception {
+        ResultActions result = mockMvc.perform(
+                get("/api/matches")
+                        .param("page", "0")
+                        .param("size", "20")
+        );
+
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(MatchApiController.class))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.result.content[0].id").isString())
+                .andExpect(jsonPath("$.result.content[0].gameMode").isString())
+                .andExpect(jsonPath("$.result.content[0].duration").isNumber())
+                .andExpect(jsonPath("$.result.content[0].mapName").isString())
+                .andExpect(jsonPath("$.result.content[0].customMatch").isBoolean())
+                .andExpect(jsonPath("$.result.content[0].matchType").isString())
+                .andExpect(jsonPath("$.result.content[0].createdAt").isString())
+        ;
+    }
+}

--- a/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
+++ b/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
@@ -7,7 +7,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -39,6 +41,23 @@ class MatchApiControllerTest {
                 .andExpect(jsonPath("$.result.content[0].customMatch").isBoolean())
                 .andExpect(jsonPath("$.result.content[0].matchType").isString())
                 .andExpect(jsonPath("$.result.content[0].createdAt").isString())
+        ;
+    }
+
+    @Transactional
+    @Test
+    void deleteById() throws Exception {
+        String id = "069990ee-ce9a-43b4-9621-8da0339b4adf";
+        ResultActions result = mockMvc.perform(
+                delete("/api/matches/" + id)
+        );
+
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(MatchApiController.class))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.result.id").value(id))
         ;
     }
 }

--- a/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
+++ b/src/test/java/com/menu/pubganalyzer/controller/api/MatchApiControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -26,7 +27,7 @@ class MatchApiControllerTest {
         ResultActions result = mockMvc.perform(
                 get("/api/matches")
                         .param("page", "0")
-                        .param("size", "20")
+                        .param("size", "5")
         );
 
         result.andDo(print())
@@ -34,6 +35,29 @@ class MatchApiControllerTest {
                 .andExpect(handler().handlerType(MatchApiController.class))
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.result.content.length()", lessThanOrEqualTo(5)))
+                .andExpect(jsonPath("$.result.content[0].id").isString())
+                .andExpect(jsonPath("$.result.content[0].gameMode").isString())
+                .andExpect(jsonPath("$.result.content[0].duration").isNumber())
+                .andExpect(jsonPath("$.result.content[0].mapName").isString())
+                .andExpect(jsonPath("$.result.content[0].customMatch").isBoolean())
+                .andExpect(jsonPath("$.result.content[0].matchType").isString())
+                .andExpect(jsonPath("$.result.content[0].createdAt").isString())
+        ;
+    }
+
+    @Test
+    void findAllDefaultPageable() throws Exception {
+        ResultActions result = mockMvc.perform(
+                get("/api/matches")
+        );
+
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(MatchApiController.class))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.result.content.length()", lessThanOrEqualTo(20)))
                 .andExpect(jsonPath("$.result.content[0].id").isString())
                 .andExpect(jsonPath("$.result.content[0].gameMode").isString())
                 .andExpect(jsonPath("$.result.content[0].duration").isNumber())

--- a/src/test/java/com/menu/pubganalyzer/domain/dao/impl/MatchDAOTest.java
+++ b/src/test/java/com/menu/pubganalyzer/domain/dao/impl/MatchDAOTest.java
@@ -118,6 +118,18 @@ class MatchDAOTest {
     }
 
     @Test
+    @DisplayName("[refactor] 매치 조회 페이징")
+    void findAll_paging() {
+        given(matchRepository.findAll(MatchFixture.PAGEABLE))
+                .willReturn(MatchFixture.MATCH_PAGE);
+
+        Page<Match> result = matchDAO.findAll(MatchFixture.PAGEABLE);
+
+        assertEquals(MatchFixture.MATCH_PAGE, result);
+        verify(matchRepository).findAll(any(Pageable.class));
+    }
+
+    @Test
     @DisplayName("매치 삭제 시 Match 캐시, Participant 캐시, DB 데이터 모두 삭제한다.")
     void deleteById() {
         given(matchCache.get(MATCH_ID, Match.class))


### PR DESCRIPTION
## 작업 내용
### 전체 조회 (페이징)
GET /api/matches?page={int}&size={int}

**ResponseBody**
```json
{
        "status": 200,
        "success": true,
        "result": "PageDTO..."
}
```

### 매치 아이디로 삭제
DELETE /api/matches/{id}

**ResponseBody**
```json
{
        "status": 200,
        "success": true,
        "result": {
                "id": "String"
        }
}