### PR TITLE
[Fix] Enum DamageCauserName WEAPFAMASG2_C 수정

### DIFF
--- a/src/main/java/com/menu/pubganalyzer/domain/model/enums/DamageCauserName.java
+++ b/src/main/java/com/menu/pubganalyzer/domain/model/enums/DamageCauserName.java
@@ -165,7 +165,7 @@ public enum DamageCauserName {
     WEAPDP28_C("DP-28", "DP-28"),
     WEAPDESERTEAGLE_C("Deagle", "Deagle"),
     WEAPDUNCANSHK416_C("M416", "M416"),
-    WeapFamasG2_C("Famas", "Famas"),
+    WEAPFAMASG2_C("Famas", "Famas"),
     WEAPFNFAL_C("SLR", "SLR"),
     WEAPG18_C("P18C", "P18C"),
     WEAPG36C_C("G36C", "G36C"),


### PR DESCRIPTION
- 데미지 로그에 파마스가 정상적으로 표시되지 않는 문제 해결.